### PR TITLE
Reduce max semaphore size

### DIFF
--- a/include/OneLibrary/ThreadsafeQueue.h
+++ b/include/OneLibrary/ThreadsafeQueue.h
@@ -18,7 +18,7 @@ namespace ol
         std::queue<T> m_qCollection{};
         // A semaphore representative of the empty spaces is not necessary, as queue will expand as needed.
         //std::numeric_limits<uint32_t>::max()
-        std::counting_semaphore<4294967295> m_sItems{0};
+        std::counting_semaphore<2147483647> m_sItems{0};
         std::binary_semaphore m_sMutex{1};
     public:
         [[nodiscard]] ThreadsafeQueue() noexcept = default;


### PR DESCRIPTION
This PR fixes an issue where compilation would fail as the semaphore size we have used was too big.
In theory, this can be much smaller but I'm fine with it the way it is. We are likely to encounter other issues before the queue gets filled up with so many events, such as server connection dropping etc.