### PR TITLE
Initial WIP groundwork for clipboard support on Windows

### DIFF
--- a/include/OneLibrary/Clipboard.h
+++ b/include/OneLibrary/Clipboard.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+#include <sstream>
+#include <iostream>
+
+namespace ol
+{
+    class Clipboard
+    {
+    private:
+        std::string m_sBuffer{};
+
+    public:
+        Clipboard();
+        ~Clipboard();
+        void SetContents(const std::string& kContents);
+        [[nodiscard]] std::string GetContents() const;
+        bool operator==(const ol::Clipboard& kClipboard) const = default;
+    };
+
+    // TODO: Current issue: As the user can copy a string with spaces in it, the clipboard data would get separated on the delimiter.
+    // Let's call to a base64 encoder first, then decode it on the receiver end.
+
+    std::istream& operator>>(std::istream& stream, ol::Clipboard& clipboard);
+    std::ostream& operator<<(std::ostream& stream, const ol::Clipboard& kClipboard);
+
+    std::stringstream& operator>>(std::stringstream& stream, ol::Clipboard& clipboard);
+    std::istringstream& operator>>(std::istringstream& stream, ol::Clipboard& clipboard);
+
+    std::stringstream& operator<<(std::stringstream& stream, const ol::Clipboard& kClipboard);
+    std::ostringstream& operator<<(std::ostringstream& stream, const ol::Clipboard& kClipboard);
+}

--- a/include/OneLibrary/Enums.h
+++ b/include/OneLibrary/Enums.h
@@ -10,7 +10,8 @@ namespace ol
         // In the future, we could implement something like `gamepad`, `steering wheel`, `bluetooth controller` etc.
 		None = 0,
         Mouse,
-		Keyboard
+		Keyboard,
+        Clipboard
 	};
 
     // The problem:
@@ -28,7 +29,8 @@ namespace ol
         MButtonMiddleUp,
         MScroll,
         KBKeyDown,
-        KBKeyUp
+        KBKeyUp,
+        ClipboardChange
     };
 
     // TODO: I wonder if we can support for example:

--- a/include/OneLibrary/Input.h
+++ b/include/OneLibrary/Input.h
@@ -7,6 +7,7 @@
 
 #include <OneLibrary/Constants.h>
 #include <OneLibrary/Enums.h>
+#include <OneLibrary/Clipboard.h>
 
 namespace ol
 {
@@ -52,6 +53,8 @@ namespace ol
 	// In the future, this could be made ASN.1-compliant.
     // TODO: Potentially turn this into a class
     // So that we can construct it with a type.
+	// Should each input have some clipboard data?
+	// Doing so would allow us to use the same pattern that we have already
 	/**
 	 * This is a platform-agnostic approach to sending the input events between different machines.
 	 */
@@ -73,6 +76,8 @@ namespace ol
 		 * Changes in keyboard state since the last event.
 		 */
 		ol::KeyboardInput keyboard = ol::KeyboardInput();
+
+		ol::Clipboard clipboard = ol::Clipboard();
 
 		bool operator==(const ol::Input&) const = default;
 	};

--- a/include/OneLibrary/InputGathererClipboard.h
+++ b/include/OneLibrary/InputGathererClipboard.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <OneLibrary/InputGatherer.h>
+
+namespace ol
+{
+    class InputGathererClipboard : public ol::InputGatherer
+    {
+    private:
+#ifdef OS_WINDOWS
+        std::thread m_thInputGatherThread;
+        WNDCLASS m_wClipboardWindowClass{};
+        HWND m_hClipboardMessageWindow{};
+        static LRESULT CALLBACK WndProc(const HWND hWnd, const UINT message, const WPARAM wParam, const LPARAM lParam);
+        void m_fWaitForClipboard();
+#endif
+
+    public:
+        // TODO: Should kAllowConsuming do anything for clipboard events?
+        explicit InputGathererClipboard(const bool kAllowConsuming = true);
+        ~InputGathererClipboard();
+        ol::Input GatherInput() override;
+        void Toggle() override;
+    };
+}

--- a/include/OneLibrary/InputGathererKeyboard.h
+++ b/include/OneLibrary/InputGathererKeyboard.h
@@ -11,6 +11,12 @@ namespace ol
     {
     private:
 #ifdef OS_WINDOWS
+        std::thread m_thInputGatherThread;
+        HHOOK m_pHook = nullptr;
+
+        WNDCLASS m_wRawInputWindowClass{};
+        HWND m_hRawInputMessageWindow{};
+
         // To avoid potential issues with calling virtual functions in the destructor, e can instead
         // call these functions which will only be defined in the current derived class and not in the base class.
         // These are currently only called on Windows.
@@ -18,13 +24,13 @@ namespace ol
         void m_fInit();
         void m_fTerminate();
 
-        void m_fStartHook() override;
-        void m_fWaitForLowLevelHook() override;
-        void m_fEndHook() override;
+        void m_fStartHook();
+        void m_fWaitForLowLevelHook();
+        void m_fEndHook();
 
-        void m_fStartRawInput() override;
-        void m_fWaitForRawInput() override;
-        void m_fEndRawInput() override;
+        void m_fStartRawInput();
+        void m_fWaitForRawInput();
+        void m_fEndRawInput();
 
         // This is what's called every time a low-level mouse event happens.
         static LRESULT CALLBACK LowLevelHookProcedure(const int nCode, const WPARAM wParam, const LPARAM lParam);

--- a/include/OneLibrary/InputGathererMouse.h
+++ b/include/OneLibrary/InputGathererMouse.h
@@ -11,6 +11,12 @@ namespace ol
     {
     private:
 #ifdef OS_WINDOWS
+        std::thread m_thInputGatherThread;
+        HHOOK m_pHook = nullptr;
+
+        WNDCLASS m_wRawInputWindowClass{};
+        HWND m_hRawInputMessageWindow{};
+
         // To avoid potential issues with calling virtual functions in the destructor, e can instead
         // call these functions which will only be defined in the current derived class and not in the base class.
         // These are currently only called on Windows.
@@ -18,13 +24,13 @@ namespace ol
         void m_fInit();
         void m_fTerminate();
 
-        void m_fStartHook() override;
-        void m_fWaitForLowLevelHook() override;
-        void m_fEndHook() override;
+        void m_fStartHook();
+        void m_fWaitForLowLevelHook();
+        void m_fEndHook();
 
-        void m_fStartRawInput() override;
-        void m_fWaitForRawInput() override;
-        void m_fEndRawInput() override;
+        void m_fStartRawInput();
+        void m_fWaitForRawInput();
+        void m_fEndRawInput();
 
         // This is what's called every time a low-level mouse event happens.
         static LRESULT CALLBACK LowLevelHookProcedure(const int nCode, const WPARAM wParam, const LPARAM lParam);

--- a/include/OneLibrary/InputSimulatorClipboard.h
+++ b/include/OneLibrary/InputSimulatorClipboard.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <OneLibrary/InputSimulator.h>
+
+namespace ol
+{
+    class InputSimulatorClipboard : public ol::InputSimulator
+    {
+    public:
+        InputSimulatorClipboard();
+        ~InputSimulatorClipboard();
+        void PerformInput(const ol::Input& kInput) override;
+    };
+}

--- a/src/OneLibrary/Clipboard.cpp
+++ b/src/OneLibrary/Clipboard.cpp
@@ -1,0 +1,60 @@
+#include <OneLibrary/Clipboard.h>
+
+namespace ol
+{
+    ol::Clipboard::Clipboard() {};
+    ol::Clipboard::~Clipboard() {};
+
+    void ol::Clipboard::SetContents(const std::string& kContents)
+    {
+        this->m_sBuffer = kContents;
+    }
+
+    std::string ol::Clipboard::GetContents() const
+    {
+        return this->m_sBuffer;
+    }
+
+    std::istream& operator>>(std::istream& stream, ol::Clipboard& clipboard)
+    {
+        std::string contents{};
+        stream >> contents;
+        clipboard.SetContents(contents);
+        return stream;
+    }
+
+    std::ostream& operator<<(std::ostream& stream, const ol::Clipboard& kClipboard)
+    {
+        stream << kClipboard.GetContents();
+        return stream;
+    }
+
+    std::stringstream& operator>>(std::stringstream& stream, ol::Clipboard& clipboard)
+    {
+        std::string contents{};
+        stream >> contents;
+        clipboard.SetContents(contents);
+        return stream;
+    }
+
+    std::istringstream& operator>>(std::istringstream& stream, ol::Clipboard& clipboard)
+    {
+        std::string contents{};
+        stream >> contents;
+        clipboard.SetContents(contents);
+        return stream;
+    }
+
+    std::stringstream& operator<<(std::stringstream& stream, const ol::Clipboard& kClipboard)
+    {
+        stream << kClipboard.GetContents();
+        return stream;
+    }
+
+    std::ostringstream& operator<<(std::ostringstream& stream, const ol::Clipboard& kClipboard)
+    {
+        stream << kClipboard.GetContents();
+        return stream;
+    }
+}
+

--- a/src/OneLibrary/Input.cpp
+++ b/src/OneLibrary/Input.cpp
@@ -66,12 +66,13 @@ namespace ol
         stream >> input.eventType;
         stream >> input.mouse;
         stream >> input.keyboard;
+        stream >> input.clipboard;
         return stream;
     }
 
     std::ostream& operator<<(std::ostream& stream, const ol::Input& kInput)
     {
-        stream << kInput.inputType << " " << kInput.eventType << " " << kInput.mouse << " " << kInput.keyboard;
+        stream << kInput.inputType << " " << kInput.eventType << " " << kInput.mouse << " " << kInput.keyboard << " " << kInput.clipboard;
         return stream;
     }
 
@@ -189,6 +190,7 @@ namespace ol
         stream >> input.eventType;
         stream >> input.mouse;
         stream >> input.keyboard;
+        stream >> input.clipboard;
         return stream;
     }
 
@@ -198,18 +200,19 @@ namespace ol
         stream >> input.eventType;
         stream >> input.mouse;
         stream >> input.keyboard;
+        stream >> input.clipboard;
         return stream;
     }
 
     std::stringstream& operator<<(std::stringstream& stream, const ol::Input& kInput)
     {
-        stream << kInput.inputType << " " << kInput.eventType << " " << kInput.mouse << " " << kInput.keyboard;
+        stream << kInput.inputType << " " << kInput.eventType << " " << kInput.mouse << " " << kInput.keyboard << " " << kInput.clipboard;
         return stream;
     }
 
     std::ostringstream& operator<<(std::ostringstream& stream, const ol::Input& kInput)
     {
-        stream << kInput.inputType << " " << kInput.eventType << " " << kInput.mouse << " " << kInput.keyboard;
+        stream << kInput.inputType << " " << kInput.eventType << " " << kInput.mouse << " " << kInput.keyboard << " " << kInput.clipboard;
         return stream;
     }
 }

--- a/src/OneLibrary/InputGatherer/Clipboard/Windows/InputGathererClipboard.cpp
+++ b/src/OneLibrary/InputGatherer/Clipboard/Windows/InputGathererClipboard.cpp
@@ -1,0 +1,154 @@
+#ifdef OS_WINDOWS
+
+#include <OneLibrary/InputGathererClipboard.h>
+
+namespace
+{
+    ol::InputGathererClipboard* Instance = nullptr;
+}
+
+ol::InputGathererClipboard::InputGathererClipboard(const bool kAllowConsuming)
+{
+    assert(!Instance);
+    Instance = this;
+    this->m_bAllowConsuming = kAllowConsuming;
+
+    std::binary_semaphore threadInitialised{0};
+    this->m_thInputGatherThread = std::thread([&]
+    {
+        // Create the window here and register it to receive clipboard messages
+        this->m_wClipboardWindowClass.lpfnWndProc = ol::InputGathererClipboard::WndProc;
+        this->m_wClipboardWindowClass.hInstance = nullptr;
+        this->m_wClipboardWindowClass.lpszClassName = L"OneLibrary - Clipboard Procedure";
+        ::RegisterClassW(&this->m_wClipboardWindowClass);
+
+        this->m_hClipboardMessageWindow = ::CreateWindowExW(WS_EX_TOOLWINDOW, this->m_wClipboardWindowClass.lpszClassName, nullptr, 0, 0, 0, 0, 0, nullptr, nullptr, nullptr, nullptr);
+
+        ::AddClipboardFormatListener(this->m_hClipboardMessageWindow);
+
+        ::MSG msg{};
+        ::PeekMessageW(&msg, this->m_hClipboardMessageWindow, WM_USER, WM_USER, PM_NOREMOVE);
+        threadInitialised.release();
+        while (this->m_bRunning) { this->m_fWaitForClipboard(); }
+    });
+
+    threadInitialised.acquire();
+}
+
+void ol::InputGathererClipboard::m_fWaitForClipboard()
+{
+    ::MSG msg{};
+    // Using the raw input message window here is okay as we have registered it as a RIDEV_INPUTSINK
+    // Unlike Low Level hooks, where the hWnd has to be nullptr.
+    const auto kResult = ::GetMessageW(&msg, this->m_hClipboardMessageWindow, WM_QUIT, WM_CLIPBOARDUPDATE);
+    if (kResult > 0)
+    {
+        // Note: Calling TranslateMessage(&msg); is only necessary for keyboard input.
+        // https://learn.microsoft.com/en-us/windows/win32/learnwin32/window-messages
+        // However, let's try not using it for the time being.
+        // Hand off every message to our Raw Input Procedure
+        ::DispatchMessageW(&msg);
+    }
+    else if (kResult == 0) // WM_QUIT message
+    {
+        this->m_bRunning = false;
+        std::cout << "Got result 0" << std::endl;
+        return;
+    }
+    else
+    {
+        // TODO: Add error handling and change these to correct return codes.
+        std::cerr << "Error occurred when getting Clipboard message" << std::endl;
+        ::PostQuitMessage(0);
+        std::exit(0);
+    }
+}
+
+ol::InputGathererClipboard::~InputGathererClipboard()
+{
+    ::PostMessageW(this->m_hClipboardMessageWindow, WM_QUIT, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(nullptr));
+    ::RemoveClipboardFormatListener(this->m_hClipboardMessageWindow);
+    ::DestroyWindow(this->m_hClipboardMessageWindow);
+    if (this->m_thInputGatherThread.joinable()) { this->m_thInputGatherThread.join(); }
+    Instance = nullptr;
+}
+
+LRESULT CALLBACK ol::InputGathererClipboard::WndProc(const HWND hWnd, const UINT message, const WPARAM wParam, const LPARAM lParam)
+{
+    ol::Input input{};
+    input.eventType = ol::eEventType::ClipboardChange;
+    input.inputType = ol::eInputType::Clipboard;
+
+    switch (message)
+    {
+        case WM_CLIPBOARDUPDATE:
+        {
+            std::cout << "Got a change in clipboard" << std::endl;
+            // Handle clipboard update message here
+
+            if (!OpenClipboard(nullptr))
+            {
+                std::cerr << "Failed to open Clipboard" << std::endl;
+                break;
+            }
+
+            const auto hData = GetClipboardData(CF_UNICODETEXT);
+            if (hData == nullptr)
+            {
+                // TODO: This fails when trying to copy files. In the future, fix it.
+                std::cerr << "Failed to get Clipboard Data. Potentially because of trying to copy a file, when only text is supported" << std::endl;
+                CloseClipboard();
+                break;
+            }
+
+            const auto pData = GlobalLock(hData);
+
+            if (pData == nullptr)
+            {
+                std::cerr << "Failed to lock Clipboard Data" << std::endl;
+                CloseClipboard();
+                break;
+            }
+
+            const auto kData = std::string(static_cast<char*>(pData), (GlobalSize(hData) / sizeof(char)));
+
+            input.clipboard.SetContents(kData);
+            std::cout << "Clipboard Data: " << kData << std::endl;
+
+            GlobalUnlock(hData);
+            CloseClipboard();
+
+            break;
+        }
+        case WM_QUIT:
+        {
+            std::cout << "Got quit message" << std::endl;
+            Instance->m_bRunning = false;
+            return 0;
+        }
+        default:
+        {
+            return DefWindowProc(hWnd, message, wParam, lParam);
+        }
+    }
+
+    if (Instance->m_bGathering)
+    {
+        Instance->m_bufInputs.Add(input);
+    }
+
+    return 0;
+}
+
+void ol::InputGathererClipboard::Toggle()
+{
+    this->m_bGathering = !this->m_bGathering;
+    this->m_bConsuming = this->m_bGathering.operator bool();
+}
+
+ol::Input ol::InputGathererClipboard::GatherInput()
+{
+    return this->m_bufInputs.Get();
+}
+
+#endif

--- a/src/OneLibrary/InputGatherer/Keyboard/Windows/InputGathererKeyboard.cpp
+++ b/src/OneLibrary/InputGatherer/Keyboard/Windows/InputGathererKeyboard.cpp
@@ -363,6 +363,7 @@ void ol::InputGathererKeyboard::m_fEndRawInput()
         // TODO: Properly define error codes.
         std::exit(-1);
     }
+    ::DestroyWindow(this->m_hRawInputMessageWindow);
 }
 
 void ol::InputGathererKeyboard::Toggle()

--- a/src/OneLibrary/InputGatherer/Mouse/Windows/InputGathererMouse.cpp
+++ b/src/OneLibrary/InputGatherer/Mouse/Windows/InputGathererMouse.cpp
@@ -405,6 +405,7 @@ void ol::InputGathererMouse::m_fEndRawInput()
         // TODO: Add enums for error messages
         std::exit(-1);
     }
+    ::DestroyWindow(this->m_hRawInputMessageWindow);
 }
 
 void ol::InputGathererMouse::Toggle()

--- a/src/OneLibrary/InputSimulator/Clipboard/Windows/InputSimulatorClipboard.cpp
+++ b/src/OneLibrary/InputSimulator/Clipboard/Windows/InputSimulatorClipboard.cpp
@@ -1,0 +1,86 @@
+#ifdef OS_WINDOWS
+
+#include <OneLibrary/InputSimulatorClipboard.h>
+
+ol::InputSimulatorClipboard::InputSimulatorClipboard()
+{
+    // Do we need to do any setup here?
+}
+
+ol::InputSimulatorClipboard::~InputSimulatorClipboard() {}
+
+void ol::InputSimulatorClipboard::PerformInput(const ol::Input &kInput)
+{
+    std::cout << "Setting clipboard data" << std::endl;
+
+    // Open the clipboard
+    if (!OpenClipboard(nullptr)) {
+        // Failed to open the clipboard
+        std::cerr << "Failed to open clipboard" << std::endl;
+        return;
+    }
+
+    if (!EmptyClipboard())
+    {
+        CloseClipboard();
+        std::cerr << "Could not clear the clipboard" << std::endl;
+        return;
+    }
+
+    // Allocate global memory for the data
+    //size_t size = (kInput.clipboard.GetContents().size() + 1) * sizeof(char);
+    //auto hMemory = GlobalAlloc(GMEM_MOVEABLE, size);
+    auto hMemory = GlobalAlloc(GMEM_MOVEABLE, kInput.clipboard.GetContents().size() + 1);
+    if (!hMemory)
+    {
+        // handle error
+        CloseClipboard();
+        std::cerr << "Could not allocate memory for the clipboard data" << std::endl;
+        return;
+    }
+
+    // Lock the memory and get a pointer to it
+    auto pMemory = static_cast<char*>(GlobalLock(hMemory));
+    if (!pMemory) {
+        // handle error
+        GlobalFree(hMemory);
+        CloseClipboard();
+        std::cout << "Could not lock memory that will store clipboard data" << std::endl;
+        return;
+    }
+
+    // Copy the data to the memory
+    // TODO: This currently only copies the first character, not the whole string.
+    std::cout << "Copying the data to clipboard" << std::endl;
+    std::cout << "Size of data (bytes): " << kInput.clipboard.GetContents().size() << std::endl;
+    std::cout << "Length of data: " << kInput.clipboard.GetContents().length() << std::endl;
+    std::cout << "Clipboard data to set: " << kInput.clipboard.GetContents() << std::endl;
+    //strcpy_s(pMemory, (kInput.clipboard.GetContents().size() + 1) * sizeof(char), kInput.clipboard.GetContents().c_str());
+    //memcpy(pMemory, kInput.clipboard.GetContents().c_str(), kInput.clipboard.GetContents().size() + 1);
+    //std::copy(pMemory, kInput.clipboard.GetContents().c_str(), kInput.clipboard.GetContents().size() + 1);
+    //std::copy(kInput.clipboard.GetContents().c_str(), kInput.clipboard.GetContents().c_str() + ((kInput.clipboard.GetContents().size() + 1) * sizeof(char)), pMemory);
+
+    memcpy_s(pMemory, kInput.clipboard.GetContents().size() + 1, kInput.clipboard.GetContents().c_str(), kInput.clipboard.GetContents().size());
+
+   // std::copy(kInput.clipboard.GetContents(), kInput.clipboard.GetContents().size(), pMemory);
+
+    //std::copy(kInput.clipboard.GetContents().begin(), kInput.clipboard.GetContents().end(), pMemory);
+    //std::copy(kInput.clipboard.GetContents().c_str(), kInput.clipboard.GetContents().c_str() + (strlen(kInput.clipboard.GetContents().c_str()) + 1) * sizeof(char), pMemory);
+
+    GlobalUnlock(hMemory);
+
+    // Set the data on the clipboard
+    if (!SetClipboardData(CF_TEXT, hMemory)) {
+        // handle error
+        std::cerr << "Could not set clipboard data" << std::endl;
+        GlobalFree(hMemory);
+        CloseClipboard();
+        return;
+    }
+
+    // Close the clipboard
+    CloseClipboard();
+    std::cout << "Clipboard data set successfully" << std::endl;
+}
+
+#endif

--- a/tests/manual/ClipboardTests.cpp
+++ b/tests/manual/ClipboardTests.cpp
@@ -1,0 +1,9 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <OneLibrary/InputGathererClipboard.h>
+
+TEST_CASE("Clipboard Gatherer receives correct message", "[InputGathererClipboard]")
+{
+    const auto kClipboardGatherer = ol::InputGathererClipboard();
+
+}


### PR DESCRIPTION
Initial groundwork for Clipboard support.

Current issues:
- Clipboard simulator only gets the first word of the clipboard contents. This is because the delimiter is the space key.
- Solution: Base64 encode it.

This PR also refactors some code.
For now, don't use the clipboard at all.