### PR TITLE
ThreadsafeQueue can now raise InterruptException

### DIFF
--- a/include/OneLibrary/InputGatherer.h
+++ b/include/OneLibrary/InputGatherer.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <thread>
 #include <cassert>
+#include <semaphore>
 
 #include <OneLibrary/Constants.h>
 #include <OneLibrary/Enums.h>
@@ -82,9 +83,11 @@ namespace ol
          * Block until this object gathered some input from the user.
          * @return The input representative of the event that has happened.
          */
-        [[nodiscard]] virtual ol::Input GatherInput() = 0;
+        [[nodiscard]] ol::Input GatherInput() noexcept(false)
+        {
+            return this->m_bufInputs.Get();
+        }
         virtual void Toggle() = 0;
         virtual void Shutdown() = 0;
-        [[nodiscard]] virtual uint64_t AvailableInputs() = 0;
     };
 }

--- a/include/OneLibrary/InputGathererClipboard.h
+++ b/include/OneLibrary/InputGathererClipboard.h
@@ -19,9 +19,7 @@ namespace ol
         // TODO: Should kAllowConsuming do anything for clipboard events?
         explicit InputGathererClipboard(const bool kAllowConsuming = true);
         ~InputGathererClipboard();
-        [[nodiscard]] ol::Input GatherInput() override;
         void Toggle() override;
         void Shutdown() override;
-        [[nodiscard]] uint64_t AvailableInputs() override;
     };
 }

--- a/include/OneLibrary/InputGathererKeyboard.h
+++ b/include/OneLibrary/InputGathererKeyboard.h
@@ -47,13 +47,7 @@ namespace ol
          */
         explicit InputGathererKeyboard(const bool kAllowConsuming = true);
         ~InputGathererKeyboard();
-        /**
-         * Blocks until a keyboard event happens.
-         * @return An input object representative of the event.
-         */
-        [[nodiscard]] ol::Input GatherInput() override;
         void Toggle() override;
         void Shutdown() override;
-        [[nodiscard]] uint64_t AvailableInputs() override;
     };
 }

--- a/include/OneLibrary/InputGathererMouse.h
+++ b/include/OneLibrary/InputGathererMouse.h
@@ -43,9 +43,7 @@ namespace ol
          */
         explicit InputGathererMouse(const bool kAllowConsuming = true);
         ~InputGathererMouse();
-        [[nodiscard]] ol::Input GatherInput() override;
         void Toggle() override;
         void Shutdown() override;
-        [[nodiscard]] uint64_t AvailableInputs() override;
     };
 }

--- a/include/OneLibrary/InterruptException.h
+++ b/include/OneLibrary/InterruptException.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <iostream>
+#include <stdexcept>
+#include <exception>
+#include <string>
+
+namespace ol
+{
+class InterruptException : public std::exception
+{
+public:
+    InterruptException() noexcept {}
+    const char* what() const noexcept override
+    {
+        return "Interrupted";
+    }
+};
+}

--- a/src/OneLibrary/InputGatherer/Clipboard/Windows/InputGathererClipboard.cpp
+++ b/src/OneLibrary/InputGatherer/Clipboard/Windows/InputGathererClipboard.cpp
@@ -148,14 +148,4 @@ void ol::InputGathererClipboard::Toggle()
     this->m_bConsuming = this->m_bGathering.operator bool();
 }
 
-ol::Input ol::InputGathererClipboard::GatherInput()
-{
-    return this->m_bufInputs.Get();
-}
-
-uint64_t ol::InputGathererClipboard::AvailableInputs()
-{
-    return this->m_bufInputs.Length();
-}
-
 #endif

--- a/src/OneLibrary/InputGatherer/Mouse/Linux/InputGathererMouse.cpp
+++ b/src/OneLibrary/InputGatherer/Mouse/Linux/InputGathererMouse.cpp
@@ -112,6 +112,7 @@ void ol::InputGathererMouse::m_fInit()
 void ol::InputGathererMouse::m_fTerminate()
 {
     if (this->m_bCalledTerminate) { return; }
+    this->m_bRunning = false;
     this->m_bCalledTerminate = true;
 
     for (auto& th: this->m_vDeviceHandlers)
@@ -146,6 +147,7 @@ void ol::InputGathererMouse::m_fTerminate()
 ol::InputGathererMouse::InputGathererMouse(const bool kAllowConsuming)
 {
     assert(!Instance);
+    if (Instance) { throw std::runtime_error{"Only one Mouse Gatherer can be active at once."}; }
     Instance = this;
     this->m_bAllowConsuming = kAllowConsuming;
     this->m_fInit();
@@ -153,7 +155,6 @@ ol::InputGathererMouse::InputGathererMouse(const bool kAllowConsuming)
 
 void ol::InputGathererMouse::m_fDeviceHandler(libevdev *device)
 {
-    // TODO: Add killswitch.
     // TODO: Add support for hotplugging devices.
 
     bool setNextRelativeX = true, setNextRelativeY = true;
@@ -401,17 +402,14 @@ void ol::InputGathererMouse::m_fSignalHandler(const int32_t kSignal)
 
 void ol::InputGathererMouse::Shutdown()
 {
+    this->m_bufInputs.Interrupt();
     this->m_fTerminate();
 }
 
 ol::InputGathererMouse::~InputGathererMouse()
 {
     this->Shutdown();
-}
-
-ol::Input ol::InputGathererMouse::GatherInput()
-{
-	return this->m_bufInputs.Get();
+    Instance = nullptr;
 }
 
 void ol::InputGathererMouse::Toggle()
@@ -423,11 +421,6 @@ void ol::InputGathererMouse::Toggle()
 
     this->m_bGathering = !this->m_bGathering;
     this->m_bConsuming = this->m_bGathering.operator bool();
-}
-
-uint64_t ol::InputGathererMouse::AvailableInputs()
-{
-    return this->m_bufInputs.Length();
 }
 
 #endif

--- a/src/OneLibrary/InputGatherer/Mouse/Windows/InputGathererMouse.cpp
+++ b/src/OneLibrary/InputGatherer/Mouse/Windows/InputGathererMouse.cpp
@@ -10,6 +10,7 @@ namespace
 ol::InputGathererMouse::InputGathererMouse(const bool kAllowConsuming)
 {
     assert(!Instance);
+    if (Instance) { throw std::runtime_error{"Only one Mouse Gatherer can be active at once."}; }
     Instance = this;
     this->m_bAllowConsuming = kAllowConsuming;
     this->m_fInit();
@@ -50,13 +51,9 @@ void ol::InputGathererMouse::m_fTerminate()
 
 ol::InputGathererMouse::~InputGathererMouse()
 {
+    this->m_bufInputs.Interrupt();
     this->m_fTerminate();
     Instance = nullptr;
-}
-
-ol::Input ol::InputGathererMouse::GatherInput()
-{
-    return this->m_bufInputs.Get();
 }
 
 void ol::InputGathererMouse::m_fStartHook()
@@ -420,11 +417,7 @@ void ol::InputGathererMouse::Toggle()
 void ol::InputGathererMouse::Shutdown()
 {
     this->m_fTerminate();
-}
-
-uint64_t ol::InputGathererMouse::AvailableInputs()
-{
-    return this->m_bufInputs.Length();
+    this->m_bufInputs.Interrupt();
 }
 
 #endif

--- a/tests/automated/ThreadsafeQueueTests.cpp
+++ b/tests/automated/ThreadsafeQueueTests.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <thread>
+
 #include <OneLibrary/ThreadsafeQueue.h>
 
 TEST_CASE("Queue can add and remove a single item", "[ThreadsafeQueue]")
@@ -12,3 +14,21 @@ TEST_CASE("Queue can add and remove a single item", "[ThreadsafeQueue]")
 }
 
 // TODO: Add test cases with multiple threads accessing the queue at the same time.
+TEST_CASE("Interrupting while Getting from an empty queue raises an exception", "[ThreadsafeQueue]")
+{
+    ol::ThreadsafeQueue<uint32_t> queue{};
+
+    std::jthread th{[&](){ std::this_thread::sleep_for(std::chrono::seconds{1}); queue.Interrupt(); }};
+
+    bool ex = false;
+    try
+    {
+        queue.Get();
+    }
+    catch (const ol::InterruptException& e)
+    {
+        ex = true;
+    }
+
+    REQUIRE(ex);
+}


### PR DESCRIPTION
This PR makes the `Get` call of the threadsafe queue being able to raise interruptexception when interrupted. This will let us quit threads that are waiting for an input to be available. This PR also removes redundant functions and adds an interrupt test for the queue.