### PR TITLE
Add CLion CMake profiles and directory labels

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeSharedSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Windows-MSVC-Debug-Static" ENABLED="true" CONFIG_NAME="Debug" TOOLCHAIN_NAME="MSVC - x64" GENERATION_OPTIONS="-G &quot;Visual Studio 17 2022&quot; -D BUILD_SHARED_LIBS=FALSE" />
+      <configuration PROFILE_NAME="Windows-MSVC-Debug-Shared" ENABLED="false" CONFIG_NAME="Debug" TOOLCHAIN_NAME="MSVC - x64" GENERATION_OPTIONS="-G &quot;Visual Studio 17 2022&quot; -D BUILD_SHARED_LIBS=TRUE" />
+      <configuration PROFILE_NAME="Windows-MSVC-Release-Static" ENABLED="true" CONFIG_NAME="Release" TOOLCHAIN_NAME="MSVC - x64" GENERATION_OPTIONS="-G &quot;Visual Studio 17 2022&quot; -D BUILD_SHARED_LIBS=FALSE" />
+      <configuration PROFILE_NAME="Windows-MSVC-Release-Shared" ENABLED="false" CONFIG_NAME="Release" TOOLCHAIN_NAME="MSVC - x64" GENERATION_OPTIONS="-G &quot;Visual Studio 17 2022&quot; -D BUILD_SHARED_LIBS=TRUE" />
+      <configuration PROFILE_NAME="Windows-GCC-Debug-Static" ENABLED="true" CONFIG_NAME="Debug" TOOLCHAIN_NAME="GCC (MinGW)" GENERATION_OPTIONS="-G &quot;MinGW Makefiles&quot; -D BUILD_SHARED_LIBS=FALSE" />
+      <configuration PROFILE_NAME="Windows-GCC-Debug-Shared" ENABLED="false" CONFIG_NAME="Debug" TOOLCHAIN_NAME="GCC (MinGW)" GENERATION_OPTIONS="-G &quot;MinGW Makefiles&quot; -D BUILD_SHARED_LIBS=TRUE" />
+      <configuration PROFILE_NAME="Windows-GCC-Release-Static" ENABLED="true" CONFIG_NAME="Release" TOOLCHAIN_NAME="GCC (MinGW)" GENERATION_OPTIONS="-G &quot;MinGW Makefiles&quot; -D BUILD_SHARED_LIBS=FALSE" />
+      <configuration PROFILE_NAME="Windows-GCC-Release-Shared" ENABLED="false" CONFIG_NAME="Release" TOOLCHAIN_NAME="GCC (MinGW)" GENERATION_OPTIONS="-G &quot;MinGW Makefiles&quot; -D BUILD_SHARED_LIBS=TRUE" />
+      <configuration PROFILE_NAME="Windows-Clang-Debug-Static" ENABLED="true" CONFIG_NAME="Debug" TOOLCHAIN_NAME="Clang (MinGW)" GENERATION_OPTIONS="-G &quot;Unix Makefiles&quot; -D BUILD_SHARED_LIBS=FALSE" />
+      <configuration PROFILE_NAME="Windows-Clang-Debug-Shared" ENABLED="false" CONFIG_NAME="Debug" TOOLCHAIN_NAME="Clang (MinGW)" GENERATION_OPTIONS="-G &quot;Unix Makefiles&quot; -D BUILD_SHARED_LIBS=TRUE" />
+      <configuration PROFILE_NAME="Windows-Clang-Release-Static" ENABLED="true" CONFIG_NAME="Release" TOOLCHAIN_NAME="Clang (MinGW)" GENERATION_OPTIONS="-G &quot;Unix Makefiles&quot; -D BUILD_SHARED_LIBS=FALSE" />
+      <configuration PROFILE_NAME="Windows-Clang-Release-Shared" ENABLED="false" CONFIG_NAME="Release" TOOLCHAIN_NAME="Clang (MinGW)" GENERATION_OPTIONS="-G &quot;Unix Makefiles&quot; -D BUILD_SHARED_LIBS=TRUE" />
+    </configurations>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+  <component name="CidrRootsConfiguration">
+    <sourceRoots>
+      <file path="$PROJECT_DIR$/include" />
+      <file path="$PROJECT_DIR$/src" />
+      <file path="$PROJECT_DIR$/tests" />
+    </sourceRoots>
+    <libraryRoots>
+      <file path="$PROJECT_DIR$/vcpkg_installed" />
+    </libraryRoots>
+    <excludeRoots>
+      <file path="$PROJECT_DIR$/.github" />
+      <file path="$PROJECT_DIR$/docs" />
+    </excludeRoots>
+  </component>
 </project>


### PR DESCRIPTION
Currently, profiles for building a shared library are disabled, as building a shared library is not supported due to no exported functions.
This PR also adds CLion labels to directories, so that for example, `docs` doesn't get indexed.